### PR TITLE
Added automatic collision creation for blocks, some fixes and refactors

### DIFF
--- a/addons/TileSetCutter/tilesetcutter.gd
+++ b/addons/TileSetCutter/tilesetcutter.gd
@@ -4,7 +4,7 @@ extends Node2D
 export(bool) var force_update setget force_update  #Forces an update_change()
 export(bool) var PadZeroes
 export(bool) var GenerateAllPalettes
-export(bool) var Collision = false setget enable_collision
+export(bool) var GenerateCollision = false setget enable_collision
 
 enum TilingType {SQUARE, ISOMETRIC, CUSTOM}
 export (TilingType) var TileType = TilingType.SQUARE
@@ -12,6 +12,7 @@ export (TilingType) var TileType = TilingType.SQUARE
 export(Vector2) var TileSize = Vector2(16,16) setget change_tile_size
 export(Vector2) var Separation = Vector2(0,0) setget change_separation
 export(Vector3) var CollisionSize = Vector3(0,0,0) setget change_collision_size
+export(Vector2) var TextureOffset = Vector2(0,0)
 export(Texture) var TextureToCut = null setget change_texture
 
 
@@ -34,7 +35,7 @@ func change_texture(value):
 			get_child(i).queue_free()
 			
 func enable_collision(value):
-	Collision = value
+	GenerateCollision = value
 	update_change()
 	
 func change_collision_size(value):
@@ -75,11 +76,12 @@ func update_change():
 					sprite.region_rect = Rect2(x*TileSize.x,y*TileSize.y,TileSize.x, TileSize.y)
 					sprite.position.x = (x * TileSize.x) + (x*Separation.x)
 					sprite.position.y = (y * TileSize.y) + (y*Separation.y)
+					sprite.offset = TextureOffset
 					
 					add_child(sprite)
 					sprite.set_owner(get_tree().get_edited_scene_root())
 					
-					if Collision:
+					if GenerateCollision:
 						create_collision_node(sprite)
 
 func create_collision_node(sprite):
@@ -99,11 +101,12 @@ func create_collision_node(sprite):
 						Vector2(CollisionSize.x/2, CollisionSize.y/2), 
 						Vector2(-CollisionSize.x/2, CollisionSize.y/2)]
 		elif TileType == TilingType.ISOMETRIC:
+			# var actualColSize = Vector3(CollisionSize.x - TextureOffset.x, CollisionSize.y - TextureOffset.y, CollisionSize.z - TextureOffset.y)
 			colPoly2d.polygon = [
-						Vector2(-CollisionSize.x, CollisionSize.y), 
-						Vector2(0, CollisionSize.z),
-						Vector2(CollisionSize.x, CollisionSize.y), 
-						Vector2(0, 0)]
+						Vector2(-CollisionSize.x + TextureOffset.x, CollisionSize.y + TextureOffset.y), 
+						Vector2(TextureOffset.x, CollisionSize.z + TextureOffset.y),
+						Vector2(CollisionSize.x + TextureOffset.x, CollisionSize.y + TextureOffset.y), 
+						Vector2(TextureOffset.x, TextureOffset.y)]
 
 		# Add the collision polygon to the static body and add it to the current scene
 		staticBody2d.add_child(colPoly2d)

--- a/addons/TileSetCutter/tilesetcutter.gd
+++ b/addons/TileSetCutter/tilesetcutter.gd
@@ -6,6 +6,9 @@ export(bool) var PadZeroes
 export(bool) var GenerateAllPalettes
 export(bool) var Collision = false setget enable_collision
 
+enum TilingType {SQUARE, ISOMETRIC, CUSTOM}
+export (TilingType) var TileType = TilingType.SQUARE
+
 export(Vector2) var TileSize = Vector2(16,16) setget change_tile_size
 export(Vector2) var Separation = Vector2(0,0) setget change_separation
 export(Vector3) var CollisionSize = Vector3(0,0,0) setget change_collision_size
@@ -80,7 +83,7 @@ func update_change():
 						create_collision_node(sprite)
 
 func create_collision_node(sprite):
-	if CollisionSize.x > 0 and CollisionSize.y > 0 and CollisionSize.z > 0:
+	if CollisionSize.x > 0 and CollisionSize.y > 0:
 		var staticBody2d = StaticBody2D.new()
 		var colPoly2d = CollisionPolygon2D.new()
 		
@@ -89,11 +92,18 @@ func create_collision_node(sprite):
 		staticBody2d.set_owner(get_tree().get_edited_scene_root())
 		
 		# Create the polygon that will be used as collision
-		colPoly2d.polygon = [
-					Vector2(-CollisionSize.x, CollisionSize.y), 
-					Vector2(0, CollisionSize.z),
-					Vector2(CollisionSize.x, CollisionSize.y), 
-					Vector2(0, 0)]
+		if TileType == TilingType.SQUARE:
+			colPoly2d.polygon = [
+						Vector2(-CollisionSize.x/2, -CollisionSize.y/2), 
+						Vector2(CollisionSize.x/2, -CollisionSize.y/2),
+						Vector2(CollisionSize.x/2, CollisionSize.y/2), 
+						Vector2(-CollisionSize.x/2, CollisionSize.y/2)]
+		elif TileType == TilingType.ISOMETRIC:
+			colPoly2d.polygon = [
+						Vector2(-CollisionSize.x, CollisionSize.y), 
+						Vector2(0, CollisionSize.z),
+						Vector2(CollisionSize.x, CollisionSize.y), 
+						Vector2(0, 0)]
 
 		# Add the collision polygon to the static body and add it to the current scene
 		staticBody2d.add_child(colPoly2d)

--- a/addons/TileSetCutter/tilesetcutter.gd
+++ b/addons/TileSetCutter/tilesetcutter.gd
@@ -1,77 +1,103 @@
 tool
 extends Node2D
 
-var index = 0
-export(bool) var ForceUpdate setget forceUpdate  #Forces an update_change()
+export(bool) var force_update setget force_update  #Forces an update_change()
 export(bool) var PadZeroes
 export(bool) var GenerateAllPalettes
-export(Vector2) var TileSize = Vector2(16,16) setget changeTileSize
-export(Vector2) var Separation = Vector2(0,0) setget changeSeparation
-export(Texture) var TextureToCut = null setget changeTexture
+export(bool) var Collision = false setget enable_collision
+
+export(Vector2) var TileSize = Vector2(16,16) setget change_tile_size
+export(Vector2) var Separation = Vector2(0,0) setget change_separation
+export(Vector3) var CollisionSize = Vector3(0,0,0) setget change_collision_size
+export(Texture) var TextureToCut = null setget change_texture
 
 
-func forceUpdate(value):
+func force_update(value):
 	update_change()
 
-func changeTileSize(value):
+func change_tile_size(value):
 	TileSize = value
 	
-func changeSeparation(value):
+func change_separation(value):
 	Separation = value
 	
-func changeTexture(value):
+func change_texture(value):
 	TextureToCut = value
-	index = 0
+	
 	if TextureToCut:
 		update_change()
 	else:
 		for i in range(0, get_child_count()):
 			get_child(i).queue_free()
+			
+func enable_collision(value):
+	Collision = value
+	update_change()
+	
+func change_collision_size(value):
+	CollisionSize = value
+	update_change()
 	
 func update_change():
 	
-	if TextureToCut != null:
-		if TileSize.x > 0 and TileSize.y > 0:
-			
-			var w  = TextureToCut.get_width()
-			var h  = TextureToCut.get_height()
-			var tx = w / TileSize.x
-			var ty = h / TileSize.y
-			
-			var zeroes = len(str(tx*ty))
-			print(zeroes)
-			
-			for i in range(0, get_child_count()):
-				get_child(i).queue_free()
-							
-			
-			
-			for y in range(ty):
-				for x in range(tx):
-					if !is_empty(TextureToCut,x*TileSize.x,y*TileSize.y,TileSize.x, TileSize.y):
-						index = (x + tx) * y
-						var sprite = Sprite.new()
-#						
-						if PadZeroes:
-							sprite.set_name(("%0" + str(zeroes) + "d") % index)
-						else:
-							sprite.set_name(str(index))
-						
-						sprite.texture = TextureToCut
-						sprite.region_enabled = true
-						sprite.region_rect = Rect2(x*TileSize.x,y*TileSize.y,TileSize.x, TileSize.y)
-						sprite.position.x = (x * TileSize.x) + (x*Separation.x)
-						sprite.position.y = (y * TileSize.y) + (y*Separation.y)
-						
-						
-						add_child(sprite)
-						sprite.set_owner(get_tree().get_edited_scene_root())
-						
+	if TextureToCut == null:
+		return
+		
+	if TileSize.x > 0 and TileSize.y > 0:
+		
+		var w  = TextureToCut.get_width()
+		var h  = TextureToCut.get_height()
+		var tx = w / TileSize.x
+		var ty = h / TileSize.y
+		
+		var zeroes = len(str(int(tx*ty)))
+		
+		for i in range(0, get_child_count()):
+			get_child(i).queue_free()
 
-	pass
-	
-func _draw():
-	pass
+		var index = 0
+		for y in range(ty):
+			for x in range(tx):
+				if !is_empty(TextureToCut, x * TileSize.x, y * TileSize.y, TileSize.x, TileSize.y):
+					index += 1
+					var sprite = Sprite.new()
+
+					if PadZeroes:
+						sprite.set_name(("%0" + str(zeroes) + "d") % index)
+					else:
+						sprite.set_name(str(index))
+					
+					sprite.texture = TextureToCut
+					sprite.region_enabled = true
+					sprite.region_rect = Rect2(x*TileSize.x,y*TileSize.y,TileSize.x, TileSize.y)
+					sprite.position.x = (x * TileSize.x) + (x*Separation.x)
+					sprite.position.y = (y * TileSize.y) + (y*Separation.y)
+					
+					add_child(sprite)
+					sprite.set_owner(get_tree().get_edited_scene_root())
+					
+					if Collision:
+						create_collision_node(sprite)
+
+func create_collision_node(sprite):
+	if CollisionSize.x > 0 and CollisionSize.y > 0 and CollisionSize.z > 0:
+		var staticBody2d = StaticBody2D.new()
+		var colPoly2d = CollisionPolygon2D.new()
+		
+		# Add the static body to the sprite and add it to the current scene
+		sprite.add_child(staticBody2d)
+		staticBody2d.set_owner(get_tree().get_edited_scene_root())
+		
+		# Create the polygon that will be used as collision
+		colPoly2d.polygon = [
+					Vector2(-CollisionSize.x, CollisionSize.y), 
+					Vector2(0, CollisionSize.z),
+					Vector2(CollisionSize.x, CollisionSize.y), 
+					Vector2(0, 0)]
+
+		# Add the collision polygon to the static body and add it to the current scene
+		staticBody2d.add_child(colPoly2d)
+		colPoly2d.set_owner(get_tree().get_edited_scene_root())
 	
 func is_empty(texture,x,y,w,h):
 	var result = true
@@ -88,7 +114,5 @@ func is_empty(texture,x,y,w,h):
 	
 	return result
 	
-	
-	
-	
-	
+func _draw():
+	pass


### PR DESCRIPTION
The pull request adds the following functionality:
- Collision creation: Setting for isometric and square collisions, being able to set the size of the collision.
- Offset: Setting to add an offset to each sprite
Fixes:
- Naming scheme for methods to follow guidelines
- Padding zeros counting the correct amount of zeros